### PR TITLE
Fix Go 1.16 installation on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ GO111MODULE=on go get github.com/sanposhiho/gomockhandler
 ```
 ### Go 1.16+
 ```
-go install github.com/golang/mock/mockgen
-go install github.com/sanposhiho/gomockhandler
+go install github.com/golang/mock/mockgen@latest
+go install github.com/sanposhiho/gomockhandler@latest
 ```
 
 ## How to use


### PR DESCRIPTION
It would be good to append `@latest` to the package identifier otherwise we get an error when installing outside of a module:
```sh
> go install github.com/sanposhiho/gomockhandler
go install: version is required when current directory is not in a module
        Try 'go install github.com/sanposhiho/gomockhandler@latest' to install the latest version
> go install github.com/sanposhiho/gomockhandler@latest
# Works as expected
```
Also, great job on the tool :)