### PR TITLE
use bufio.Reader instead of bufio.Scanner

### DIFF
--- a/internal/util/files.go
+++ b/internal/util/files.go
@@ -52,22 +52,16 @@ func ReadALine(filename string) (string, error) {
 	}
 
 	buf := bytes.NewBuffer(data)
-	if cont {
-		for {
-			data, cont, err = r.ReadLine()
-			if err == io.EOF {
-				break
-			} else if err != nil {
-				return "", fmt.Errorf("error to read the file: %w", err)
-			}
+	for cont {
+		data, cont, err = r.ReadLine()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return "", fmt.Errorf("error to read the file: %w", err)
+		}
 
-			if _, err = buf.Write(data); err != nil {
-				return "", fmt.Errorf("error to append data to buffer: %w", err)
-			}
-
-			if !cont {
-				break
-			}
+		if _, err = buf.Write(data); err != nil {
+			return "", fmt.Errorf("error to append data to buffer: %w", err)
 		}
 	}
 

--- a/internal/util/files.go
+++ b/internal/util/files.go
@@ -2,9 +2,10 @@ package util
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 )
@@ -43,15 +44,32 @@ func ReadALine(filename string) (string, error) {
 		return "", fmt.Errorf("error to open the file: %w", err)
 	}
 
-	var line string
-	fileScanner := bufio.NewScanner(file)
-	for fileScanner.Scan() {
-		line = fileScanner.Text()
-		break
-	}
-	if err := fileScanner.Err(); err != nil {
-		log.Fatalf("error to scan the file: %s", err)
+	r := bufio.NewReader(file)
+
+	data, cont, err := r.ReadLine()
+	if err != nil && err != io.EOF {
+		return "", fmt.Errorf("error to read the file: %w", err)
 	}
 
-	return line, nil
+	buf := bytes.NewBuffer(data)
+	if cont {
+		for {
+			data, cont, err = r.ReadLine()
+			if err == io.EOF {
+				break
+			} else if err != nil {
+				return "", fmt.Errorf("error to read the file: %w", err)
+			}
+
+			if _, err = buf.Write(data); err != nil {
+				return "", fmt.Errorf("error to append data to buffer: %w", err)
+			}
+
+			if !cont {
+				break
+			}
+		}
+	}
+
+	return buf.String(), nil
 }


### PR DESCRIPTION
`gomockhandler check` is failed when scan the large single line file.
Because ~os~ of hard limit of bufio.Scanner.

So use bufio.Reader to scan first line of file.

P.S.
There is another approach like filtering target files using extension, etc...