### PR TITLE
Fix how to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,13 @@ And with this background, it is designed to make it easy to switch from managing
 You have to install `mockgen` first.
 
 ```
-go install go.uber.org/mock/mockgen@latest
+go install github.com/golang/mock/mockgen@latest
+```
+
+Next, install gomockhandler.
+
+```
+go install github.com/sanposhiho/gomockhandler@latest
 ```
 
 ## How to use

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ And with this background, it is designed to make it easy to switch from managing
 You have to install `mockgen` first.
 
 ```
-go install github.com/golang/mock/mockgen@latest
+go install go.uber.org/mock/mockgen@latest
 ```
 
 Next, install gomockhandler.


### PR DESCRIPTION
I updated the readme of mockgen to reference the latest package, as it was previously referring to an outdated one. Additionally, I have added instructions on how to install gomockhandler itself.