### PR TITLE
fix: log of CalculateCheckSum func

### DIFF
--- a/internal/util/random.go
+++ b/internal/util/random.go
@@ -12,7 +12,7 @@ import (
 func CalculateCheckSum(filePath string) (string, error) {
 	file, err := ioutil.ReadFile(filePath)
 	if err != nil {
-		return "", fmt.Errorf("failed read file. filename: %s, err: %w", filePath)
+		return "", fmt.Errorf("failed read file. filename: %s, err: %w", filePath, err)
 	}
 
 	hash := md5.Sum(file)


### PR DESCRIPTION
This commit fixes an issue in the CalculateCheckSum function where the error message was not formatted correctly. The error formatting has been corrected to include the error variable.