### PR TITLE
Update check command to replace tmp file path in comment out section

### DIFF
--- a/internal/command/generate_config.go
+++ b/internal/command/generate_config.go
@@ -1,12 +1,12 @@
 package command
 
 import (
+	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
 
 	"github.com/sanposhiho/gomockhandler/internal/mockgen"
-
 	"github.com/sanposhiho/gomockhandler/internal/model"
 	"github.com/sanposhiho/gomockhandler/internal/util"
 )
@@ -60,8 +60,13 @@ func (r Runner) GenerateConfig() {
 		log.Fatalf("failed to run mockgen: %v \nPlease run `%s` and check if mockgen works correctly with your options", err, r.MockgenRunner)
 	}
 
+	file, err := ioutil.ReadFile(r.MockgenRunner.GetDestination())
+	if err != nil {
+		log.Fatalf("failed read file. filename: %s, err: %w", r.MockgenRunner.GetDestination(), err)
+	}
+
 	// calculate mock's check sum
-	checksum, err := util.CalculateCheckSum(r.MockgenRunner.GetDestination())
+	checksum, err := util.CalculateCheckSum(file)
 	if err != nil {
 		log.Fatalf("failed to calculate checksum of the mock: %v", err)
 	}

--- a/internal/command/mockgen.go
+++ b/internal/command/mockgen.go
@@ -84,7 +84,7 @@ func (r Runner) Mockgen() {
 			}
 			file, err := ioutil.ReadFile(r.MockgenRunner.GetDestination())
 			if err != nil {
-				log.Fatalf("failed read file. filename: %s, err: %w", r.MockgenRunner.GetDestination(), err)
+				return fmt.Errorf("failed read file. filename: %s, err: %w", r.MockgenRunner.GetDestination(), err)
 			}
 			checksum, err := util.CalculateCheckSum(file)
 			if err != nil {

--- a/internal/command/mockgen.go
+++ b/internal/command/mockgen.go
@@ -3,19 +3,19 @@ package command
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 
 	"github.com/sanposhiho/gomockhandler/internal/mockgen"
-
 	"github.com/sanposhiho/gomockhandler/internal/model"
 	"github.com/sanposhiho/gomockhandler/internal/util"
-	"golang.org/x/sync/errgroup"
 )
 
 func (r Runner) Mockgen() {
@@ -82,8 +82,11 @@ func (r Runner) Mockgen() {
 			if err != nil {
 				return fmt.Errorf("failed to run mockgen: %v \nPlease run `%s` and check if mockgen works correctly with your options", err, runner)
 			}
-
-			checksum, err := util.CalculateCheckSum(runner.GetDestination())
+			file, err := ioutil.ReadFile(r.MockgenRunner.GetDestination())
+			if err != nil {
+				log.Fatalf("failed read file. filename: %s, err: %w", r.MockgenRunner.GetDestination(), err)
+			}
+			checksum, err := util.CalculateCheckSum(file)
 			if err != nil {
 				return fmt.Errorf("calculate checksum of the mock: %v", err)
 			}

--- a/internal/mockgen/runner.go
+++ b/internal/mockgen/runner.go
@@ -2,7 +2,10 @@ package mockgen
 
 import (
 	"fmt"
+	"io/ioutil"
+	"log"
 	"os"
+	"regexp"
 
 	"github.com/sanposhiho/gomockhandler/internal/util"
 )
@@ -18,18 +21,25 @@ type Runner interface {
 
 func Checksum(r Runner) (string, error) {
 	d := r.GetDestination()
-	tmpFile := util.TmpFilePath(d)
-	defer os.Remove(tmpFile)
+	tmpFilePath := util.TmpFilePath(d)
+	defer os.Remove(tmpFilePath)
 
 	// use tmpfile to test generating mock
-	r.SetDestination(tmpFile)
+	r.SetDestination(tmpFilePath)
 	defer r.SetDestination(d)
 
 	if err := r.Run(); err != nil {
 		return "", fmt.Errorf("failed to run mockgen: %v \nPlease run `%s` and check if mockgen works correctly with your options", err, r)
 	}
 
-	checksum, err := util.CalculateCheckSum(tmpFile)
+	tmpFile, err := ioutil.ReadFile(tmpFilePath)
+	if err != nil {
+		log.Fatalf("failed read file. filename: %s, err: %w", tmpFilePath, err)
+	}
+
+	adjustedFile := replaceTmpPathWithOriginal(tmpFilePath, tmpFile)
+
+	checksum, err := util.CalculateCheckSum([]byte(adjustedFile))
 	if err != nil {
 		return "", fmt.Errorf("calculate checksum of the mock: %v", err)
 	}
@@ -37,8 +47,18 @@ func Checksum(r Runner) (string, error) {
 	return checksum, nil
 }
 
+func replaceTmpPathWithOriginal(tmpFilePath string, tmpFile []byte) string {
+	originFilePath := util.RemoveTmpPrefix(tmpFilePath)
+	re := regexp.MustCompile("(//.+mockgen.+-destination=)(" + tmpFilePath + ")")
+	return re.ReplaceAllString(string(tmpFile), "${1}"+originFilePath)
+}
+
 func SourceChecksum(r Runner) (string, error) {
-	checksum, err := util.CalculateCheckSum(r.GetSource())
+	file, err := ioutil.ReadFile(r.GetSource())
+	if err != nil {
+		log.Fatalf("failed read file. filename: %s, err: %w", r.GetSource(), err)
+	}
+	checksum, err := util.CalculateCheckSum(file)
 	if err != nil {
 		return "", fmt.Errorf("calculate checksum of the mock source: %v", err)
 	}

--- a/internal/mockgen/runner.go
+++ b/internal/mockgen/runner.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/sanposhiho/gomockhandler/internal/util"
 )
@@ -48,7 +49,7 @@ func Checksum(r Runner) (string, error) {
 }
 
 func replaceTmpPathWithOriginal(tmpFilePath string, tmpFile []byte) string {
-	originFilePath := util.RemoveTmpPrefix(tmpFilePath)
+	originFilePath := strings.Replace(tmpFilePath, "tmp_", "", 1)
 	re := regexp.MustCompile("(//.+mockgen.+-destination=)(" + tmpFilePath + ")")
 	return re.ReplaceAllString(string(tmpFile), "${1}"+originFilePath)
 }

--- a/internal/mockgen/runner.go
+++ b/internal/mockgen/runner.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/sanposhiho/gomockhandler/internal/util"
@@ -48,7 +49,8 @@ func Checksum(r Runner) (string, error) {
 }
 
 func replaceTmpPathWithOriginal(tmpFilePath string, tmpFile []byte) string {
-	originFilePath := strings.Replace(tmpFilePath, "tmp_", "", 1)
+	d, f := filepath.Split(tmpFilePath)
+	originFilePath := filepath.Join(d, strings.Replace(f, "tmp_", "", 1))
 	return strings.Replace(string(tmpFile), tmpFilePath, originFilePath, 1)
 }
 

--- a/internal/mockgen/runner.go
+++ b/internal/mockgen/runner.go
@@ -3,7 +3,6 @@ package mockgen
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"regexp"
 
@@ -34,7 +33,7 @@ func Checksum(r Runner) (string, error) {
 
 	tmpFile, err := ioutil.ReadFile(tmpFilePath)
 	if err != nil {
-		log.Fatalf("failed read file. filename: %s, err: %w", tmpFilePath, err)
+		return "", fmt.Errorf("failed read file. filename: %s, err: %w", tmpFilePath, err)
 	}
 
 	adjustedFile := replaceTmpPathWithOriginal(tmpFilePath, tmpFile)
@@ -56,7 +55,7 @@ func replaceTmpPathWithOriginal(tmpFilePath string, tmpFile []byte) string {
 func SourceChecksum(r Runner) (string, error) {
 	file, err := ioutil.ReadFile(r.GetSource())
 	if err != nil {
-		log.Fatalf("failed read file. filename: %s, err: %w", r.GetSource(), err)
+		return "", fmt.Errorf("failed read file. filename: %s, err: %w", r.GetSource(), err)
 	}
 	checksum, err := util.CalculateCheckSum(file)
 	if err != nil {

--- a/internal/mockgen/runner.go
+++ b/internal/mockgen/runner.go
@@ -36,6 +36,7 @@ func Checksum(r Runner) (string, error) {
 		return "", fmt.Errorf("failed read file. filename: %s, err: %w", tmpFilePath, err)
 	}
 
+	// See https://github.com/sanposhiho/gomockhandler/issues/88
 	adjustedFile := replaceTmpPathWithOriginal(tmpFilePath, tmpFile)
 
 	checksum, err := util.CalculateCheckSum([]byte(adjustedFile))

--- a/internal/mockgen/runner.go
+++ b/internal/mockgen/runner.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"regexp"
 	"strings"
 
 	"github.com/sanposhiho/gomockhandler/internal/util"
@@ -50,8 +49,7 @@ func Checksum(r Runner) (string, error) {
 
 func replaceTmpPathWithOriginal(tmpFilePath string, tmpFile []byte) string {
 	originFilePath := strings.Replace(tmpFilePath, "tmp_", "", 1)
-	re := regexp.MustCompile("(//.+mockgen.+-destination=)(" + tmpFilePath + ")")
-	return re.ReplaceAllString(string(tmpFile), "${1}"+originFilePath)
+	return strings.Replace(string(tmpFile), tmpFilePath, originFilePath, 1)
 }
 
 func SourceChecksum(r Runner) (string, error) {

--- a/internal/util/random.go
+++ b/internal/util/random.go
@@ -3,24 +3,12 @@ package util
 import (
 	"crypto/md5"
 	"encoding/base64"
-	"fmt"
-	"io/ioutil"
 	"path/filepath"
-	"regexp"
 	"strings"
 )
 
-func CalculateCheckSum(filePath string) (string, error) {
-	file, err := ioutil.ReadFile(filePath)
-	if err != nil {
-		return "", fmt.Errorf("failed read file. filename: %s, err: %w", filePath, err)
-	}
-
-	originFilePath := OriginFilePathFromTmpFilePath(filePath)
-	re := regexp.MustCompile("(//.+mockgen.+-destination=)(" + filePath + ")")
-	trimmedFile := re.ReplaceAllString(string(file), "${1}"+originFilePath)
-
-	hash := md5.Sum([]byte(trimmedFile))
+func CalculateCheckSum(file []byte) (string, error) {
+	hash := md5.Sum(file)
 	strhash := base64.StdEncoding.EncodeToString(hash[:])
 	return strhash, nil
 }
@@ -34,6 +22,6 @@ func TmpFilePath(original string) string {
 	return d + "tmp_" + f
 }
 
-func OriginFilePathFromTmpFilePath(tmpFilePath string) string {
+func RemoveTmpPrefix(tmpFilePath string) string {
 	return strings.Replace(tmpFilePath, "tmp_", "", 1)
 }

--- a/internal/util/random.go
+++ b/internal/util/random.go
@@ -21,7 +21,3 @@ func TmpFilePath(original string) string {
 	d, f := filepath.Split(original)
 	return d + "tmp_" + f
 }
-
-func RemoveTmpPrefix(tmpFilePath string) string {
-	return strings.Replace(tmpFilePath, "tmp_", "", 1)
-}


### PR DESCRIPTION
## Issue
Fixes https://github.com/sanposhiho/gomockhandler/issues/88

## changed
- add replace process ded11c2a867624b9defee1945ccfba7626e05820
- refactor func CalculateCheckSum so that the replace process only works when running check command 157a3f24957acdf88bdfcdb16e111657644b4fa5

## replace process
I created a regular expression that corresponds to [go.uber.org/mock/mockgen@v0.4.0](https://github.com/uber-go/mock/blob/74a29c6e6c2cbb8ccee94db061c1604ff33fd188/mockgen/mockgen.go#L324) and [go.uber.org/mock/mockgen@v0.3.0](https://github.com/uber-go/mock/blob/57226e5165e3d73d9693fd4f4decf0d67258fdec/mockgen/mockgen.go#L318). (There are no comments that need to be fixed in v0.1.0 and v0.2.0.)

**e.g.**
  
Before:
`//      mockgen -destination=usecases/mock/tmp_xxx.go`

After:
`//      mockgen -destination=usecases/mock/xxx.go`

Thank you !!