### PR TITLE
fix: mockgen command

### DIFF
--- a/internal/command/mockgen.go
+++ b/internal/command/mockgen.go
@@ -82,7 +82,7 @@ func (r Runner) Mockgen() {
 			if err != nil {
 				return fmt.Errorf("failed to run mockgen: %v \nPlease run `%s` and check if mockgen works correctly with your options", err, runner)
 			}
-			file, err := ioutil.ReadFile(r.MockgenRunner.GetDestination())
+			file, err := ioutil.ReadFile(runner.GetDestination())
 			if err != nil {
 				return fmt.Errorf("failed read file. filename: %s, err: %w", r.MockgenRunner.GetDestination(), err)
 			}

--- a/internal/command/mockgen.go
+++ b/internal/command/mockgen.go
@@ -84,7 +84,7 @@ func (r Runner) Mockgen() {
 			}
 			file, err := ioutil.ReadFile(runner.GetDestination())
 			if err != nil {
-				return fmt.Errorf("failed read file. filename: %s, err: %w", r.MockgenRunner.GetDestination(), err)
+				return fmt.Errorf("failed read file. filename: %s, err: %w", runner.GetDestination(), err)
 			}
 			checksum, err := util.CalculateCheckSum(file)
 			if err != nil {


### PR DESCRIPTION
### Actual behavior
`gomockhandler -config=./gomockhandler.json mockgen` the following error occurs.

```
gomockhandler -config=./gomockhandler.json mockgen
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x1049f13b4]

goroutine 24 [running]:
github.com/sanposhiho/gomockhandler/internal/command.Runner.Mockgen.func1()
        /Users/shoyo/gomockhandler/internal/command/mockgen.go:85 +0x504
golang.org/x/sync/errgroup.(*Group).Go.func1()
        /Users/shoyo/go/pkg/mod/golang.org/x/sync@v0.0.0-20190423024810-112230192c58/errgroup/errgroup.go:57 +0x60
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 1
        /Users/shoyo/go/pkg/mod/golang.org/x/sync@v0.0.0-20190423024810-112230192c58/errgroup/errgroup.go:54 +0x84
make: *** [generate] Error 2

```
### Expected behavior
gomockhandler -config=./gomockhandler.json mockgen command works correctly.


### Related Pull Request

[The following changes](https://github.com/sanposhiho/gomockhandler/pull/89/files) were not good.
![image](https://github.com/sanposhiho/gomockhandler/assets/41041296/71f4294b-8d8a-4c00-9e3d-652ba4fcb19c)

sorry, 
I only checked `gomockhandler -config=./gomockhandler.json check` and did not check `gomockhandler -config=./gomockhandler.json mockgen` 🙇 . 

