### PR TITLE
Add Configuration File Support for Overriding mockgen_cmd in gomockhandler

### DIFF
--- a/internal/command/check.go
+++ b/internal/command/check.go
@@ -92,7 +92,7 @@ func (r Runner) Check() {
 				}
 			}
 
-			checksum, err := mockgen.Checksum(runner)
+			checksum, err := mockgen.Checksum(runner, ch.GetMockgenCmd())
 			if err != nil {
 				return fmt.Errorf("get checksum: %v", err)
 			}

--- a/internal/command/generate_config.go
+++ b/internal/command/generate_config.go
@@ -56,7 +56,7 @@ func (r Runner) GenerateConfig() {
 		}
 	}
 
-	if err := r.MockgenRunner.Run(); err != nil {
+	if err := r.MockgenRunner.Run(chunk.GetMockgenCmd()); err != nil {
 		log.Fatalf("failed to run mockgen: %v \nPlease run `%s` and check if mockgen works correctly with your options", err, r.MockgenRunner)
 	}
 

--- a/internal/command/mockgen.go
+++ b/internal/command/mockgen.go
@@ -78,7 +78,7 @@ func (r Runner) Mockgen() {
 				}
 			}
 
-			err = runner.Run()
+			err = runner.Run(ch.GetMockgenCmd())
 			if err != nil {
 				return fmt.Errorf("failed to run mockgen: %v \nPlease run `%s` and check if mockgen works correctly with your options", err, runner)
 			}

--- a/internal/mockgen/reflectmode/runner.go
+++ b/internal/mockgen/reflectmode/runner.go
@@ -77,14 +77,19 @@ func (r *Runner) GetSource() string {
 	return r.Source
 }
 
-func (r *Runner) String() string {
-	params := append(r.options(), []string{r.PackageName, r.Interfaces}...)
-	return exec.Command("mockgen", params...).String()
+func (r *Runner) cmd(mockgenCmd []string) *exec.Cmd {
+	cmd := mockgenCmd
+	cmd = append(cmd, r.options()...)
+	cmd = append(cmd, []string{r.PackageName, r.Interfaces}...)
+	return exec.Command(cmd[0], cmd[1:]...)
 }
 
-func (r *Runner) Run() error {
-	params := append(r.options(), []string{r.PackageName, r.Interfaces}...)
-	return exec.Command("mockgen", params...).Run()
+func (r *Runner) String(mockgenCmd []string) string {
+	return r.cmd(mockgenCmd).String()
+}
+
+func (r *Runner) Run(mockgenCmd []string) error {
+	return r.cmd(mockgenCmd).Run()
 }
 
 func (r *Runner) options() []string {

--- a/internal/mockgen/runner.go
+++ b/internal/mockgen/runner.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Runner interface {
-	Run() error
+	Run(mockgenCmd []string) error
 
 	SetSource(new string)
 	GetSource() string
@@ -19,7 +19,7 @@ type Runner interface {
 	GetDestination() string
 }
 
-func Checksum(r Runner) (string, error) {
+func Checksum(r Runner, mockgenCmd []string) (string, error) {
 	d := r.GetDestination()
 	tmpFilePath := util.TmpFilePath(d)
 	defer os.Remove(tmpFilePath)
@@ -28,7 +28,7 @@ func Checksum(r Runner) (string, error) {
 	r.SetDestination(tmpFilePath)
 	defer r.SetDestination(d)
 
-	if err := r.Run(); err != nil {
+	if err := r.Run(mockgenCmd); err != nil {
 		return "", fmt.Errorf("failed to run mockgen: %v \nPlease run `%s` and check if mockgen works correctly with your options", err, r)
 	}
 

--- a/internal/mockgen/sourcemode/runner.go
+++ b/internal/mockgen/sourcemode/runner.go
@@ -60,12 +60,18 @@ func (r *Runner) GetSource() string {
 	return r.Source
 }
 
-func (r *Runner) String() string {
-	return exec.Command("mockgen", r.options()...).String()
+func (r *Runner) cmd(mockgenCmd []string) *exec.Cmd {
+	cmd := mockgenCmd
+	cmd = append(cmd, r.options()...)
+	return exec.Command(cmd[0], cmd[1:]...)
 }
 
-func (r *Runner) Run() error {
-	return exec.Command("mockgen", r.options()...).Run()
+func (r *Runner) String(mockgenCmd []string) string {
+	return r.cmd(mockgenCmd).String()
+}
+
+func (r *Runner) Run(mockgenCmd []string) error {
+	return r.cmd(mockgenCmd).Run()
 }
 
 func (r *Runner) options() []string {

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -1,10 +1,15 @@
 package model
 
-import "errors"
+import (
+	"errors"
+	"strings"
+)
 
 type Config struct {
 	// key: destination
 	Mocks map[string]*Mock `json:"mocks"`
+
+	MockgenCmd string `json:"mockgen_cmd,omitempty"`
 }
 
 func NewChunk() *Config {
@@ -28,4 +33,11 @@ func (c *Config) Find(destination string) (*Mock, error) {
 		return m, nil
 	}
 	return nil, ErrNotFound
+}
+
+func (c *Config) GetMockgenCmd() []string {
+	if c.MockgenCmd == "" {
+		return []string{"mockgen"}
+	}
+	return strings.Fields(c.MockgenCmd)
 }


### PR DESCRIPTION
When using gomockhandler in a team setting, it is essential to standardize the version of mockgen. Currently, each team member needs to manually align their local version of mockgen.

By allowing the override of mockgen, we can specify the version as follows:

```
go run go.uber.org/mock/mockgen@v0.4.0
```

However, specifying the mockgen_cmd through gomockhandler options presents an issue because the go:generate directive does not support options with spaces (quotation will be ignored).

As a temporary workaround, I propose adding a setting to the configuration file that allows the override of the mockgen_cmd. This will enable team-wide consistency without the need for manual version alignment on each developer's machine.