### PR TITLE
Add final newline to gomockhandler config file

### DIFF
--- a/internal/repository/config/config.go
+++ b/internal/repository/config/config.go
@@ -19,7 +19,7 @@ func (r *Repository) Put(m *model.Config, path string) error {
 	if err != nil {
 		return fmt.Errorf("json marshal: %w", err)
 	}
-	return os.WriteFile(path, d, 0644)
+	return os.WriteFile(path, append(d, '\n'), 0644)
 }
 
 func (r *Repository) Get(path string) (*model.Config, error) {


### PR DESCRIPTION
To ensure that the generated files include a final newline at the end, similar to the behavior of [json.Encoder.Encode](https://pkg.go.dev/encoding/json#Encoder.Encode), which automatically adds a newline after encoding.

> Encode writes the JSON encoding of v to the stream, with insignificant space characters elided, followed by a newline character.



Many development tools and text editors expect files to end with a newline. Adding a final newline ensures better compatibility with tools such as Git, diff utilities, and build systems, which may otherwise raise warnings or display unnecessary diffs.


